### PR TITLE
Remove the gvector_print macro

### DIFF
--- a/include/ginger/vector.h
+++ b/include/ginger/vector.h
@@ -45,11 +45,6 @@ if (v) { v[gvector_len(v)++] = x; } else { raise(SIGSEGV); }
 
 #define gvector_pop(v) if (v && gvector_len(v) > 0) { --gvector_len(v); }
 
-#define gvector_print(fmt, v) do \
-{ \
-  for (size_t i = 0; i < gvector_len(v); ++i) printf(fmt, v[i]); \
-} while(0);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
I am pretty well convinced that there is no clean, generic way of implementing a print function for the vector type. Closes #3 